### PR TITLE
[Fix] 롤링 페이퍼 리스트 인기순 정렬 로직 수정

### DIFF
--- a/src/api/list-api.js
+++ b/src/api/list-api.js
@@ -1,25 +1,33 @@
-const TEAM = '15-5'; // 팀 이름 설정
-const BASE_URL = `https://rolling-api.vercel.app/${TEAM}/recipients`; // API URL
-const HEADERS = {
-  'Content-Type': 'application/json',
-};
+const TEAM = '15-5';
+const BASE_URL = `https://rolling-api.vercel.app/${TEAM}/recipients`;
+const HEADERS = { 'Content-Type': 'application/json' };
 
-// 롤링 리스트 가져오기 (모든 데이터 불러오기)
-export async function fetchRollingList() {
+/**
+ * 전체 페이지를 순회하며 모든 결과를 합쳐 반환합니다.
+ */
+export async function fetchAllRollingList() {
   try {
-    const response = await fetch(`${BASE_URL}/?team=${TEAM}`, {
-      method: 'GET',
-      headers: HEADERS,
-    });
+    const limit = 100;   // 한 번에 가져올 개수 (API 허용 범위 내에서 조정)
+    let page = 1;
+    let allResults = [];
 
-    if (!response.ok) {
-      throw new Error('롤링 리스트를 불러오는 데 실패했습니다.');
+    while (true) {
+      const offset = (page - 1) * limit;
+      const res = await fetch(
+        `${BASE_URL}/?team=${TEAM}&limit=${limit}&offset=${offset}`,
+        { method: 'GET', headers: HEADERS }
+      );
+      if (!res.ok) throw new Error('롤링 페이지 리스트를 불러오는 데 실패했습니다.');
+
+      const data = await res.json();
+      allResults = allResults.concat(data.results);
+
+      // 마지막 페이지면 중단
+      if (data.results.length < limit) break;
+      page++;
     }
 
-    // JSON 응답 처리
-    const data = await response.json();
-
-    return data; // 전체 데이터를 반환
+    return { results: allResults };
   } catch (error) {
     console.error('API 요청 오류:', error);
     throw error;

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import styles from '../styles/Pages/ListPage.module.css';
-import { fetchRollingList } from '../api/list-api';
+import { fetchAllRollingList } from '../api/list-api';
 import Header from '../components/common/Header';
 import Button from '../components/common/Button';
 import buttonStyles from '../styles/Button.module.css';
@@ -24,7 +24,7 @@ export default function ListPage() {
   const startX = useRef(0);
   const isDragging = useRef(false);
 
-  // 태블릿(≤1023px) 여부
+  // 태블릿 여부 판단
   const [isTablet, setIsTablet] = useState(window.innerWidth <= 1023);
   useEffect(() => {
     const onResize = () => setIsTablet(window.innerWidth <= 1023);
@@ -32,11 +32,12 @@ export default function ListPage() {
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  // 데이터 로딩
+  // 전체 데이터 한 번에 가져오기
   useEffect(() => {
     (async () => {
+      setLoading(true);
       try {
-        const data = await fetchRollingList();
+        const data = await fetchAllRollingList();
         setList(data.results);
       } catch (e) {
         console.error(e);
@@ -46,23 +47,17 @@ export default function ListPage() {
     })();
   }, [location.pathname]);
 
-  // 정렬 & 슬라이스
+  // 인기순 & 최근순 목록
   const popularList = [...list]
-    .sort((a, b) => b.recentMessages.length - a.recentMessages.length)
+  // 메시지를 가장 많이 받은 순으로 전체 정렬 후 상위 8개 추출
+    .sort((a, b) => b.messageCount - a.messageCount)
     .slice(0, 8);
   const recentList = [...list]
     .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
     .slice(0, 8);
 
-  // 버튼 핸들러 (prev는 동일)
-  const prevSlide = useCallback(() => {
-    setCurrentIndex(i => Math.max(0, i - 1));
-  }, []);
-  const prevRecent = useCallback(() => {
-    setRecentIndex(i => Math.max(0, i - 1));
-  }, []);
-
-  // next: 태블릿일 땐 +1 허용
+  // 슬라이드 핸들러
+  const prevSlide = useCallback(() => setCurrentIndex(i => Math.max(0, i - 1)), []);
   const nextSlide = useCallback(() => {
     setCurrentIndex(i => {
       const baseMax = popularList.length - VISIBLE;
@@ -71,6 +66,7 @@ export default function ListPage() {
     });
   }, [popularList.length, isTablet]);
 
+  const prevRecent = useCallback(() => setRecentIndex(i => Math.max(0, i - 1)), []);
   const nextRecent = useCallback(() => {
     setRecentIndex(i => {
       const baseMax = recentList.length - VISIBLE;
@@ -79,7 +75,7 @@ export default function ListPage() {
     });
   }, [recentList.length, isTablet]);
 
-  // 드래그 시작/끝 핸들러
+  // 드래그 제어
   const onDragStart = e => {
     const x = e.touches?.[0].clientX ?? e.clientX;
     startX.current = x;
@@ -94,34 +90,20 @@ export default function ListPage() {
     isDragging.current = false;
   };
 
-  // 배경용 맵
-  const colorMap = {
-    beige: '#FFE2AD',
-    purple: '#ECD9FF',
-    blue: '#B1E4FF',
-    green: '#D0F5C3',
-  };
-  const imageMap = {
-    beige: '/images/yellow-backimg.png',
-    purple: '/images/purple-backimg.png',
-    blue: '/images/blue-backimg.png',
-    green: '/images/green-backimg.png',
-  };
+  // 배경 스타일 매핑
+  const colorMap = { beige: '#FFE2AD', purple: '#ECD9FF', blue: '#B1E4FF', green: '#D0F5C3' };
+  const imageMap = { beige: '/images/yellow-backimg.png', purple: '/images/purple-backimg.png', blue: '/images/blue-backimg.png', green: '/images/green-backimg.png' };
   const getBG = (url, color) =>
     url
       ? { backgroundImage: `url(${url})`, backgroundSize: 'cover', backgroundPosition: 'center' }
       : { backgroundColor: colorMap[color], backgroundImage: `url(${imageMap[color]})`, backgroundSize: '50%', backgroundPosition: 'bottom right' };
 
-  // 렌더링 공통 캐러셀
+  // 공통 캐러셀 렌더링
   const renderCarousel = (data, idx, onPrev, onNext) => {
-    // 실제 너비 계산
-    const wrapperWidth = data.length * CARD_WIDTH + (data.length) * GAP;
+    const wrapperWidth = data.length * CARD_WIDTH + data.length * GAP;
     const containerWidth = VISIBLE * CARD_WIDTH + (VISIBLE - 1) * GAP;
     const maxTranslate = wrapperWidth - containerWidth;
-    // idx*STEP 을 maxTranslate 이하로 캡핑
     const move = Math.min(idx * STEP, maxTranslate);
-
-    // 버튼 disabled 기준
     const baseMax = data.length - VISIBLE;
     const maxIdx = isTablet ? baseMax + 1 : baseMax;
 
@@ -133,71 +115,61 @@ export default function ListPage() {
           ) : (
             <div
               className={styles['list-page__card-wrapper']}
-              style={{
-                width: `${wrapperWidth}px`,
-                transform: `translateX(-${move}px)`,
-                transition: 'transform 0.5s ease',
-                overflow: 'hidden',
-                cursor: isDragging.current ? 'grabbing' : 'grab',
-              }}
+              style={{ width: wrapperWidth, transform: `translateX(-${move}px)`, transition: 'transform 0.5s ease', cursor: isDragging.current ? 'grabbing' : 'grab' }}
               onTouchStart={onDragStart}
               onMouseDown={onDragStart}
               onTouchEnd={e => onDragEnd(e, onNext, onPrev)}
               onMouseUp={e => onDragEnd(e, onNext, onPrev)}
               onMouseLeave={() => (isDragging.current = false)}
             >
-              {data.map(item => (
-                <div
-                  key={item.id}
-                  className={`${styles['list-page__card']} ${item.backgroundImageURL ? styles.imgOn : ''}`}
-                  style={getBG(item.backgroundImageURL, item.backgroundColor)}
-                  onClick={() => navigate(`/post/${item.id}`)}
-                >
-                  <p className={styles['list-page__recipient']}>To. {item.name}</p>
-                  <div className={styles['list-page__profile-wrap']}>
-                    {item.recentMessages.slice(0, 3).map((m, i) => (
-                      <img
-                        key={m.id}
-                        src={m.profileImageURL || '/icons/profile.png'}
-                        className={styles['list-page__profile-image']}
-                        style={{ left: `${i * 16}px` }}
-                      />
-                    ))}
-                    {item.recentMessages.length > 3 && (
-                      <span className={styles['list-page__profile-count']}>+{item.recentMessages.length - 3}</span>
-                    )}
-                  </div>
-                  <p className={styles['list-page__count']}>
-                    <span>{item.recentMessages.length}</span>명이 작성했어요!
-                  </p>
-                  <div className={styles['list-page__emoji-container']}>
-                    {item.topReactions?.map((r, i) => {
-                      // count가 0이면 아무 것도 그리지 않음
-                      if (r.count === 0) return null;
-                      return (
-                        <span key={i} className={styles['list-page__box-emoji']}>
-                          <span className={styles['list-page__real-emoji']}>
-                            {r.emoji}
+              {data.map(item => {
+                // 상위 3개 프로필
+                const profileImages = item.recentMessages.slice(0, 3);
+                // 전체 메시지 수 또는 고유 작성자 수를 사용하려면 item.messageCount 또는 고유 set 사이즈로 교체
+                const totalCount = item.messageCount; // API에서 제공하는 전체 작성자/메시지 수 사용
+                const extraCount = totalCount - profileImages.length;
+
+                return (
+                  <div
+                    key={item.id}
+                    className={`${styles['list-page__card']} ${item.backgroundImageURL ? styles.imgOn : ''}`}
+                    style={getBG(item.backgroundImageURL, item.backgroundColor)}
+                    onClick={() => navigate(`/post/${item.id}`)}
+                  >
+                    <p className={styles['list-page__recipient']}>To. {item.name}</p>
+                    <div className={styles['list-page__profile-wrap']}>                      
+                      {profileImages.map((m, i) => (
+                        <img
+                          key={m.id}
+                          src={m.profileImageURL || '/icons/profile.png'}
+                          className={styles['list-page__profile-image']}
+                          style={{ left: `${i * 16}px` }}
+                        />
+                      ))}
+                      {extraCount > 0 && (
+                        <span className={styles['list-page__profile-count']}>+{extraCount}</span>
+                      )}
+                    </div>
+                    <p className={styles['list-page__count']}><span>{totalCount}</span>명이 작성했어요!</p>
+                    <div className={styles['list-page__emoji-container']}>
+                      {item.topReactions?.map((r, i) =>
+                        r.count > 0 && (
+                          <span key={i} className={styles['list-page__box-emoji']}>
+                            <span className={styles['list-page__real-emoji']}>{r.emoji}</span>
+                            <span className={styles['list-page__num-emoji']}>{r.count}</span>
                           </span>
-                          <span className={styles['list-page__num-emoji']}>
-                            {r.count}
-                          </span>
-                        </span>
-                      );
-                    })}
+                        )
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>
         <div className={styles['carousel-buttons-container']}>
-          <button onClick={onPrev} disabled={idx === 0} className={styles['carousel-button']}>
-            ❮
-          </button>
-          <button onClick={onNext} disabled={idx >= maxIdx} className={styles['carousel-button']}>
-            ❯
-          </button>
+          <button onClick={onPrev} disabled={idx === 0} className={styles['carousel-button']}>❮</button>
+          <button onClick={onNext} disabled={idx >= maxIdx} className={styles['carousel-button']}>❯</button>
         </div>
       </>
     );
@@ -206,21 +178,16 @@ export default function ListPage() {
   return (
     <div className={styles['list-page']}>
       <Header />
-
       <div className={styles['list-page__popular']}>
         <h2>인기 롤링 페이퍼 🔥</h2>
         {renderCarousel(popularList, currentIndex, prevSlide, nextSlide)}
       </div>
-
       <div className={styles['list-page__recent']}>
         <h2>최근에 만든 롤링 페이퍼 ⭐️️</h2>
         {renderCarousel(recentList, recentIndex, prevRecent, nextRecent)}
       </div>
-
       <div className={styles['list-page__buttons']}>
-        <Button onClick={() => navigate('/post')} className={buttonStyles.button__primary}>
-          나도 만들어보기
-        </Button>
+        <Button onClick={() => navigate('/post')} className={buttonStyles.button__primary}>나도 만들어보기</Button>
       </div>
     </div>
   );

--- a/src/styles/Pages/ListPage.module.css
+++ b/src/styles/Pages/ListPage.module.css
@@ -56,6 +56,9 @@
     font-size: 24px;
     line-height: 36px;
     color: #181818;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .list-page__card .list-page__profile-wrap {
@@ -156,7 +159,6 @@
 } */
 
 .imgOn .list-page__recipient,
-.imgOn .list-page__profile-count,
 .imgOn .list-page__count {
     color: #fff;
 }

--- a/src/styles/Pages/ListPage.module.css
+++ b/src/styles/Pages/ListPage.module.css
@@ -221,6 +221,10 @@
     .list-page__card-container {
         padding-left: 24px;
     }
+
+    .carousel-buttons-container {
+        display: none !important;
+    }
 } 
 
 /* 모바일 (해상도 ~767px)*/ 


### PR DESCRIPTION
## 📌 개요
- 롤링 페이퍼 리스트 인기순 정렬 로직 수정

## ✅ 작업 내용
- 전체 api 받아온 후 메시지를 보낸 사람이 많은 순대로 정렬
- 최대 8개 노출

## 🔧 특이사항
- 없음